### PR TITLE
Cleanup: Multisig

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,11 +33,6 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     implementation 'org.web3j:core:4.5.14'
 
-    /*
-    implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
-    implementation 'io.reactivex.rxjava3:rxjava:3.0.0'
-
-     */
 
     //rxjava
     implementation "io.reactivex.rxjava2:rxjava:2.2.0"

--- a/app/src/main/java/com/example/web3wallet/MainActivity.java
+++ b/app/src/main/java/com/example/web3wallet/MainActivity.java
@@ -435,18 +435,7 @@ public class MainActivity extends AppCompatActivity {
 
     }
 
-    // TODO: replace remotecall to Completable Future and async method
-    public String GetWalletByJid(String JID) {   // TODO: check
-        RemoteCall<String> WalletInstance = kns.GetWalletByJid(JID);
-        return WalletInstance.toString();
-    }
-
-    // TODO: replace remotecall to Completable Future and async method
-    public String GetWalletByTel(String telephone) {   // TODO: check
-        RemoteCall<String> WalletInstance = kns.GetWalletByTel(telephone);
-        return WalletInstance.toString();
-    }
-
+ 
 
 
 

--- a/app/src/main/java/com/example/web3wallet/MainActivity.java
+++ b/app/src/main/java/com/example/web3wallet/MainActivity.java
@@ -51,23 +51,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 
-
-//import io.reactivex.rxjava3.core.*;
-//import io.reactivex.rxjava3.*;
-//import io.reactivex.Observable;
-
-
-import io.reactivex.Observable;
-import io.reactivex.Single;
-import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.schedulers.Schedulers;
-import kotlin.ArrayIntrinsicsKt;
-
-
-import static com.onehilltech.promises.Promise.await;
-import static com.onehilltech.promises.Promise.resolve;
-
-
 public class MainActivity extends AppCompatActivity {
 
 
@@ -82,12 +65,12 @@ public class MainActivity extends AppCompatActivity {
     public static Credentials credentials;
 
     public static KNS kns;
-    public static SuperFactory superfactory;
+  //  public static SuperFactory superfactory;
     public static TicketFactory721 ticketfactory;
     public Ticket721 ticket;
 
     public static String kns_address;
-    public static String sup_factory_address;
+  //  public static String sup_factory_address;
     public static String ticket_factory_address;
 
     private String deployed_net_id;
@@ -126,11 +109,6 @@ public class MainActivity extends AppCompatActivity {
 
         setupContracts();
       //  checkContractAddresses();
-
-
-
-
-
 
     }
 
@@ -292,13 +270,7 @@ public class MainActivity extends AppCompatActivity {
 
     /*  CALLS FROM UI HERE */
 
-    public void createSimpleMultisigWalletTestView(View v) {
-        createSimpleMultisigWalletTest();
-    }
 
-    public void createMultipleMultisigWalTestView(View v) {
-        createMultisigWalTest();
-    }
 
     public void StartGeneralTicketActivity(View v) {
         Intent intent = new Intent(this,TicketGeneralActivity.class);
@@ -365,233 +337,81 @@ public class MainActivity extends AppCompatActivity {
     // setting up instances of smart contracts
     public void setupContracts() {
 
-        // FIXME: can't automatically get net id from artifacts, probably bug
-        /*
-        try{
-            String net_id =  web3.netVersion().send().getNetVersion();
-            deployed_net_id = net_id;
-        } catch (Exception e) {
-            Log.e("exeption", "can't get version of network (network id), check deployment script "+e);
-            Log.e("exeption","can't get version of network (network id), check deployment script",e);
-        }
-        */
-
         // FIXME: check net id for local and cloud enviroment
-        String net_id = "5777";  // 5777 - for ganache (local testing)
+        String net_id = "5777";  // 5777 - for ganache (local testing)  , 42 - moonshard private network (has not been deployed yet)
         deployed_net_id = net_id;
 
+        kns_address = KNS.getPreviouslyDeployedAddress(deployed_net_id);                    // Registry contract
+      //  sup_factory_address = SuperFactory.getPreviouslyDeployedAddress(deployed_net_id);   // Multisigs factory contract, this one is deprecated as we do need to make multisigs now
+        ticket_factory_address = TicketFactory721.getPreviouslyDeployedAddress(deployed_net_id); // Ticket Factory contract
 
-
-        kns_address = KNS.getPreviouslyDeployedAddress(deployed_net_id);
-        sup_factory_address = SuperFactory.getPreviouslyDeployedAddress(deployed_net_id);
-        ticket_factory_address = TicketFactory721.getPreviouslyDeployedAddress(deployed_net_id);
-
-        Log.d("deployed_address", "kns_address: "+kns_address);
-        Log.d("deployed_address", "sup_factory_address: "+sup_factory_address);
+      //  Log.d("deployed_address", "kns_address: "+kns_address);
+      //  Log.d("deployed_address", "sup_factory_address: "+sup_factory_address);
         Log.d("deployed_address", "ticket_factory_address: "+ticket_factory_address);
 
 
-        ContractGasProvider gasprovider = new DefaultGasProvider();
-
-        Log.d("gasLimit", "gasLimit: "+gasprovider.getGasLimit());
+        ContractGasProvider gasprovider = new DefaultGasProvider();     // default (network dynamic gasprovider)
+      //  Log.d("gasLimit", "gasLimit: "+gasprovider.getGasLimit());    // uncomment this if you want to know network gas info
        // gasprovider.getGasLimit();
+      //  Log.d("gasLimit", "custom gas limit: " + CUSTOM_GAS_LIMIT); // check out that our own custom gas limit was properly setted
 
-        Log.d("gasLimit", "custom gas limit: " + CUSTOM_GAS_LIMIT);
-
-
-
-
-        kns = KNS.load(kns_address,web3,credentials,CUSTOM_GAS_PRICE,CUSTOM_GAS_LIMIT);
-        String check = kns.getContractAddress();
-        Log.d("instance_address", "KNS address: "+check);
 
       //  superfactory = SuperFactory.load(sup_factory_address,web3,credentials,new DefaultGasProvider()); //FIXME: change default gas provider to custom.  We will need this for invoking functions with gasprice = 0
       //  ticketfactory = TicketFactory721.load(ticket_factory_address,web3,credentials,new DefaultGasProvider()); // FIXME: probably could workaround with custom transaction calls. need to check that.
 
 
-        superfactory = SuperFactory.load(sup_factory_address,web3,credentials,CUSTOM_GAS_PRICE,CUSTOM_GAS_LIMIT);
+        kns = KNS.load(kns_address,web3,credentials,CUSTOM_GAS_PRICE,CUSTOM_GAS_LIMIT);                 // entangle java contract artifact to actuall contract
+       // superfactory = SuperFactory.load(sup_factory_address,web3,credentials,CUSTOM_GAS_PRICE,CUSTOM_GAS_LIMIT);         // we are not using superfactory now
         ticketfactory = TicketFactory721.load(ticket_factory_address,web3,credentials,CUSTOM_GAS_PRICE,CUSTOM_GAS_LIMIT);
-        //ticket = Ticket721.
-
-        // Check
-        Log.d("instance_address", "superfactory address:"+superfactory.getContractAddress());
-        Log.d("instance_address ", "ticketfactory address:"+ticketfactory.getContractAddress());
-
     }
 
-
-    public String createSimpleMultisigWalletTest() {
-        String _owner = getMyAddress();
-        BigInteger _required = new BigInteger("1");
-        BigInteger _dailyLimit = new BigInteger("10000");
-        String JID = "cheburek@conference.moonhsard.tech";
-        String telephone = "79687003680";
-
-
-        String txHash = createSimpleMultisigWallet(_owner,_required,_dailyLimit,JID,telephone);
-
-
-
-        return txHash;
-    }
-
-    // function createMultisigWallet with multiple owners
-    public Void createMultisigWalTest() {
-
-        String _owner = getMyAddress();
-        BigInteger _required = new BigInteger("1");
-        BigInteger _dailyLimit = new BigInteger("10000");
-        String JID = "cheburek@conference.moonhsard.tech";
-        String telephone = "79687003680";
-
-        createMultisigWal(_owner,_required,_dailyLimit,JID,telephone);
-        return null;
-    }
-
-    // Main function to create (Register) Standard MULTISignature wallet
-    public void createMultisigWal(String _owner,BigInteger _required, BigInteger _dailyLimit, String JID, String telephone) {
-
-
-        List<String> _owners = new ArrayList<String>();
-
-        _owners.add(_owner);
-
-        try {
-            CompletableFuture<TransactionReceipt> receipt = superfactory.createWallet(_owners,_required,_dailyLimit,JID,telephone).sendAsync();
-            receipt.thenAccept(transactionReceipt -> {
-                // get tx receipt only if successful
-                String txHash = transactionReceipt.getTransactionHash(); // can play with that
-                // vtxHash = txHash;
-                Log.d("receipt", "receipt"+transactionReceipt);
-                Log.d("txhash", "txhash:" +txHash);
-            }).exceptionally(transactionReceipt -> {
-
-                return null;
-            });
-
-            String txHash = receipt.get().getTransactionHash();
-          //  TransactionReceipt recept = receipt.get();
-          //  event = recept.
-            //   TransactionReceipt txReceipt = receiptProcessor.waitForTransactionReceipt(txHash);
-            Log.d("txHash", "createMultipleMultisigWallet RESULT HASH: "+txHash);
-        } catch (Exception e) {
-            // Log.d("tx hash", "txhash"+txHash);
-            Log.e("tx exeption", "createMultipleMultisigWallet Transaction fails:",e);
-
-        }
-
-    }
-
+    //WARN: DEPRECATED
+    // Saved this function for EXAMPLE OF USAGE
+    /*
     // Main function to create (Register) Simple Multisignature wallet with 2fa and replacer already setted at factory contract
     public String createSimpleMultisigWallet(String _owner,BigInteger _required, BigInteger _dailyLimit, String JID, String telephone) {  //TODO: refactor this as main register wallet function, cleanup others
-
-       // TransactionReceipt recept;
-
-        /*
-        TransactionReceiptProcessor receiptProcessor =
-                new PollingTransactionReceiptProcessor(web3, TransactionManager.DEFAULT_POLLING_FREQUENCY,
-                        TransactionManager.DEFAULT_POLLING_ATTEMPTS_PER_TX_HASH);
-        */
-
         String vtxHash = null;
-
         try {
-            CompletableFuture<TransactionReceipt> receipt = superfactory.createSimpleWallet(_owner, _required, _dailyLimit, JID, telephone).sendAsync();
+            CompletableFuture<TransactionReceipt> receipt = superfactory.createSimpleWallet(_owner, _required, _dailyLimit, JID, telephone).sendAsync(); // create simple multisig wallet
             receipt.thenAccept(transactionReceipt -> {
                 // get tx receipt only if successful
                 String txHash = transactionReceipt.getTransactionHash(); // can play with that
 
                // EventValues eventValues = kns.getRegistredHumanEvents(transactionReceipt);
-                List eventResponseHuman = kns.getRegistredHumanEvents(transactionReceipt);
-
-
-
-
+                List eventResponseHuman = kns.getRegistredHumanEvents(transactionReceipt);  // get events from tx receipt
                 Log.d("event_values_human", "event_response: " + eventResponseHuman);
 
 
                 List eventValues = kns.getRegistredEvents(transactionReceipt);
                 Log.d("event_values", "event_values: " + eventValues);
-
-
-
                 Log.d("receipt", "receipt"+transactionReceipt);
                 Log.d("txhash", "txhash:" +txHash);
-
             }).exceptionally(transactionReceipt -> {
-
                 return null;
-
             });
-
 
             String txHash = receipt.get().getTransactionHash();
             vtxHash = txHash;
             List log = receipt.get().getLogs();
 
-            List<KNS.RegistredHumanEventResponse> response = kns.getRegistredHumanEvents(receipt.get());
+            List<KNS.RegistredHumanEventResponse> response = kns.getRegistredHumanEvents(receipt.get()); //alternate call for events
 
-            String JID_responce = response.get(0).JID;
+            String JID_responce = response.get(0).JID; // get value of event
             String wallet_responce = response.get(0).wallet;
             String telephone_responce = response.get(0).tel;
             String prime_owner_responce = response.get(0).prime_owner;
 
-
-
-
             Log.d("event_response", "event_Human_registred_response: " +response);
             Log.d("event_values", "event values: " + JID_responce + " " + telephone_responce + " " + prime_owner_responce + " " + wallet_responce);
             Log.d("resultat", "new wallet address is: " + wallet_responce);
-
-
-
             Log.d("txHash", "createSimpleMultisigWallet RESULT: "+txHash);
             Log.d("events logs", "event_logs:" +log);
         } catch (Exception e) {
             Log.e("tx exeption", "createMultisigWallet Transaction fails:",e);
         }
-
         return vtxHash;
-
-
     }
-
-
-
-
-    // For testing purposes
-    public void checkContractAddresses() {
-
-      //  kns_address = KNS.;
-       // sup_factory_address = SuperFactory.getPreviouslyDeployedAddress(deployed_net_id);
-      //  ticket_factory_address = TicketFactory721.getPreviouslyDeployedAddress(deployed_net_id);
-
-      //  Log.d("address", "kns_address: "+kns_address);
-      //  Log.d("address", "sup_factory_address: "+sup_factory_address);
-      //  Log.d("address", "ticket_factory_address: "+ticket_factory_address);
-
-        try {
-            String kns_address_check = KNS.getPreviouslyDeployedAddress("5777");
-            Log.d("address check", "KNS address (1 check): "+kns_address_check); // works fine
-
-        } catch (Exception e) {
-            Log.e("exeption", "unable to get contract address: ",e);
-        }
-
-       // 5777 - is for ganache
-       String kns_address_check = KNS.getPreviouslyDeployedAddress("5777");
-        Log.d("address check", "KNS address (2 check): "+kns_address_check); // works fine
-
-
-      //  kns = KNS.load(KNS.getContractAddress(),web3,credentials,new DefaultGasProvider());
-
-        kns = KNS.load(kns_address_check,web3,credentials,new DefaultGasProvider());  // worked only with loaded credentials (!!)
-        String check = kns.getContractAddress();
-        Log.d("try to retrive address(2)", "KNS address (3 check): "+check);
-    }
-
-
-
+*/
 
     // Send Funds to address
     public void SendEtherToAddress(String recepient, Float amount ) {

--- a/app/src/main/java/com/example/web3wallet/ManageTicketSaleActivity.java
+++ b/app/src/main/java/com/example/web3wallet/ManageTicketSaleActivity.java
@@ -19,7 +19,6 @@ import java.math.BigInteger;
 import java.util.concurrent.CompletableFuture;
 
 import static com.example.web3wallet.MainActivity.credentials;
-import static com.example.web3wallet.MainActivity.superfactory;
 import static com.example.web3wallet.MainActivity.ticketfactory;
 
 public class ManageTicketSaleActivity extends AppCompatActivity {

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -136,28 +136,6 @@
             app:layout_constraintStart_toEndOf="@+id/balanceHint"
             app:layout_constraintTop_toBottomOf="@+id/editPass" />
 
-        <Button
-            android:id="@+id/buttonMSW"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="72dp"
-            android:onClick="createSimpleMultisigWalletTestView"
-            android:text="CreateMultiSig test"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/sendToInput" />
-
-        <Button
-            android:id="@+id/button2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:onClick="createMultipleMultisigWalTestView"
-            android:text="create Multi wallet test"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/buttonMSW" />
-
         <EditText
             android:id="@+id/amountTo"
             android:layout_width="wrap_content"

--- a/drafts/drafts_multisig.txt
+++ b/drafts/drafts_multisig.txt
@@ -1,0 +1,112 @@
+ // Main function to create (Register) Standard MULTISignature wallet
+    public void createMultisigWal(String _owner,BigInteger _required, BigInteger _dailyLimit, String JID, String telephone) {
+
+
+        List<String> _owners = new ArrayList<String>();
+
+        _owners.add(_owner);
+
+        try {
+            CompletableFuture<TransactionReceipt> receipt = superfactory.createWallet(_owners,_required,_dailyLimit,JID,telephone).sendAsync();
+            receipt.thenAccept(transactionReceipt -> {
+                // get tx receipt only if successful
+                String txHash = transactionReceipt.getTransactionHash(); // can play with that
+                // vtxHash = txHash;
+                Log.d("receipt", "receipt"+transactionReceipt);
+                Log.d("txhash", "txhash:" +txHash);
+            }).exceptionally(transactionReceipt -> {
+
+                return null;
+            });
+
+            String txHash = receipt.get().getTransactionHash();
+          //  TransactionReceipt recept = receipt.get();
+          //  event = recept.
+            //   TransactionReceipt txReceipt = receiptProcessor.waitForTransactionReceipt(txHash);
+            Log.d("txHash", "createMultipleMultisigWallet RESULT HASH: "+txHash);
+        } catch (Exception e) {
+            // Log.d("tx hash", "txhash"+txHash);
+            Log.e("tx exeption", "createMultipleMultisigWallet Transaction fails:",e);
+
+        }
+
+    }
+
+
+
+ // Main function to create (Register) Simple Multisignature wallet with 2fa and replacer already setted at factory contract
+    public String createSimpleMultisigWallet(String _owner,BigInteger _required, BigInteger _dailyLimit, String JID, String telephone) {  //TODO: refactor this as main register wallet function, cleanup others
+
+       // TransactionReceipt recept;
+
+        /*
+        TransactionReceiptProcessor receiptProcessor =
+                new PollingTransactionReceiptProcessor(web3, TransactionManager.DEFAULT_POLLING_FREQUENCY,
+                        TransactionManager.DEFAULT_POLLING_ATTEMPTS_PER_TX_HASH);
+        */
+
+        String vtxHash = null;
+
+        try {
+            CompletableFuture<TransactionReceipt> receipt = superfactory.createSimpleWallet(_owner, _required, _dailyLimit, JID, telephone).sendAsync();
+            receipt.thenAccept(transactionReceipt -> {
+                // get tx receipt only if successful
+                String txHash = transactionReceipt.getTransactionHash(); // can play with that
+
+               // EventValues eventValues = kns.getRegistredHumanEvents(transactionReceipt);
+                List eventResponseHuman = kns.getRegistredHumanEvents(transactionReceipt);
+
+
+
+
+                Log.d("event_values_human", "event_response: " + eventResponseHuman);
+
+
+                List eventValues = kns.getRegistredEvents(transactionReceipt);
+                Log.d("event_values", "event_values: " + eventValues);
+
+
+
+                Log.d("receipt", "receipt"+transactionReceipt);
+                Log.d("txhash", "txhash:" +txHash);
+
+            }).exceptionally(transactionReceipt -> {
+
+                return null;
+
+            });
+
+
+            String txHash = receipt.get().getTransactionHash();
+            vtxHash = txHash;
+            List log = receipt.get().getLogs();
+
+            List<KNS.RegistredHumanEventResponse> response = kns.getRegistredHumanEvents(receipt.get());
+
+            String JID_responce = response.get(0).JID;
+            String wallet_responce = response.get(0).wallet;
+            String telephone_responce = response.get(0).tel;
+            String prime_owner_responce = response.get(0).prime_owner;
+
+
+
+
+            Log.d("event_response", "event_Human_registred_response: " +response);
+            Log.d("event_values", "event values: " + JID_responce + " " + telephone_responce + " " + prime_owner_responce + " " + wallet_responce);
+            Log.d("resultat", "new wallet address is: " + wallet_responce);
+
+
+
+            Log.d("txHash", "createSimpleMultisigWallet RESULT: "+txHash);
+            Log.d("events logs", "event_logs:" +log);
+        } catch (Exception e) {
+            Log.e("tx exeption", "createMultisigWallet Transaction fails:",e);
+        }
+
+        return vtxHash;
+
+
+
+
+    }
+


### PR DESCRIPTION
- Cleanup unused code that invoke creation multisigs as we don't use multisigs right now. Old methods for multisigs can be found at `./drafts`

- Cleanup unused dependencies

- Cleanup unused superfactory calls (superfactory is multisig factory contract)
- Clean up unused public address getters from KNS contract

todos for next better chore: 
1. you can delete all deprecated (commented) methods
2. you can remove superfactory contract artifact from project as we are not use multisigs pattern now
